### PR TITLE
Fix spelling error (s/occured/occurred/).

### DIFF
--- a/src/mathic/error.cpp
+++ b/src/mathic/error.cpp
@@ -15,7 +15,7 @@ namespace mathic {
 
     std::ostringstream err;
     err << errorMsg << '\n'
-        << "The internal error occured in file " << file
+        << "The internal error occurred in file " << file
         << " on line " << lineNumber << '.';
     reportInternalError(err.str());
   }


### PR DESCRIPTION
Was causing a spelling-error-in-binary Lintian warning in the Debian
package.
