### PR TITLE
Use the noreturn annotation for better compiler diagnostics.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,7 +10,7 @@ libmathic_la_CPPFLAGS = $(DEPS_CFLAGS)
 lib_LTLIBRARIES = libmathic.la
 
 # set the C++ compiler to include src/
-AM_CXXFLAGS=-I$(top_srcdir)/src/ -std=gnu++0x
+AM_CXXFLAGS=-I$(top_srcdir)/src/ -std=gnu++14
 
 # libraries that are needed by this library
 libmathic_la_LIBADD= $(DEPS_LIBS)
@@ -85,7 +85,7 @@ if with_gtest
 TESTS=unittest
 check_PROGRAMS=$(TESTS)
 
-unittest_CXXFLAGS = -I$(top_srcdir)/src/ -std=gnu++0x
+unittest_CXXFLAGS = -I$(top_srcdir)/src/ -std=gnu++14
 unittest_LDADD = $(top_builddir)/libmathic.la $(DEPS_LIBS) -lmemtailor -lpthread
 unittest_CPPFLAGS = $(DEPS_CFLAGS)
 

--- a/src/mathic/error.cpp
+++ b/src/mathic/error.cpp
@@ -2,15 +2,15 @@
 #include <sstream>
 
 namespace mathic {
-  void reportError(const std::string& errorMsg) {
+  void reportError [[noreturn]] (const std::string& errorMsg) {
     throw MathicException("ERROR: " + errorMsg);
   }
 
-  void reportInternalError(const std::string& errorMsg) {
+  void reportInternalError [[noreturn]] (const std::string& errorMsg) {
     throw InternalMathicException("INTERNAL ERROR: " + errorMsg);
   }
 
-  void reportInternalError
+  void reportInternalError [[noreturn]]
   (const std::string& errorMsg, const char* file, unsigned int lineNumber) {
 
     std::ostringstream err;

--- a/src/mathic/error.h
+++ b/src/mathic/error.h
@@ -18,26 +18,19 @@ namespace mathic {
     InternalMathicException(const std::string& str): logic_error(str) {}
   };
 
-  // The do {...} while (0) is to collect everything into a single
-  // statement that still requires a semicolon after it. The throw is to
-  // prevent spurious compiler warnings about a missing return
-  // statement.
   #define MATHIC_INTERNAL_ERROR(msg) \
-    do { \
-      reportInternalError(msg, __FILE__, __LINE__); \
-      throw; \
-    } while (false)
+    reportInternalError(msg, __FILE__, __LINE__)
   #define INTERNAL_ERROR_UNIMPLEMENTED() \
     INTERNAL_ERROR("Called function that has not been implemented.")
 
   // These methods throw exceptions.
-  void reportError(const std::string& errorMsg);
-  void reportInternalError(const std::string& errorMsg);
-  void reportInternalError
+  void reportError [[noreturn]] (const std::string& errorMsg);
+  void reportInternalError [[noreturn]] (const std::string& errorMsg);
+  void reportInternalError [[noreturn]]
   (const std::string& errorMsg, const char* file, unsigned int lineNumber);
 
   template<class Exception>
-  void throwError(const std::string& errorMsg) {
+  void throwError [[noreturn]] (const std::string& errorMsg) {
     throw Exception("ERROR: " + errorMsg + '\n');
   }
 


### PR DESCRIPTION
This requires C++11 or later, but many packages do nowadays.  This commit not only allows MATHIC_INTERNAL_ERROR to be simplified, but also eliminates a number of compiler warnings (with g++, at least) in mathicgb.