### PR TITLE
initalize _back in Bucket to prevent some warnings

### DIFF
--- a/src/mathic/Geobucket.h
+++ b/src/mathic/Geobucket.h
@@ -773,11 +773,12 @@ namespace mathic {
   template<class C>
   Geobucket<C>::Bucket::Bucket
 	(size_t capacity, Entry* buffer, Entry* otherBuffer):
-  _frontPos(0),
-	_otherBuffer(otherBuffer),
-	_begin(buffer),
-	_size(0),
-	_capacity(capacity) {
+        _frontPos(0),
+        _otherBuffer(otherBuffer),
+        _back(),
+        _begin(buffer),
+        _size(0),
+        _capacity(capacity) {
 	  MATHIC_ASSERT(C::bucketStorage == GeoStoreDoubleBuffer ?
 			 otherBuffer != 0 : otherBuffer == 0);
 	}


### PR DESCRIPTION
This was causing warnings about uninitialized values when used in M2. Also I wasn't quite sure what was going on with the indentation previously, so I just reindented the whole block of initializations.