### PR TITLE
Constify Cmp::operator()

### DIFF
--- a/src/mathic/StlSet.h
+++ b/src/mathic/StlSet.h
@@ -56,7 +56,7 @@ namespace mathic {
 	Configuration _conf;
 	struct Cmp {
     Cmp(const Configuration* conf): _conf(conf) {}
-	  bool operator()(const Entry& a, const Entry& b) {
+	  bool operator()(const Entry& a, const Entry& b) const {
 		return _conf->cmpLessThan(_conf->compare(b, a));
 	  }
 	  const Configuration* _conf; // should be &, but gcc complains


### PR DESCRIPTION
In conjunction with https://github.com/Macaulay2/mathic/pull/14, this change prevents a warning when building with C++17.